### PR TITLE
Use node address as gerrit db host

### DIFF
--- a/classes/cluster/try-mcp/cicd/init.yml
+++ b/classes/cluster/try-mcp/cicd/init.yml
@@ -155,7 +155,7 @@ parameters:
           service:
             server:
               environment:
-                DB_PORT_3306_TCP_ADDR: gerrit_db
+                DB_PORT_3306_TCP_ADDR: ${_param:single_address}
     host:
       pkgs:
         - docker-ce


### PR DESCRIPTION
We need to have gerrit db host available out of docker
to be able to run jeepyb manage-project successfully.